### PR TITLE
Simplify Step hierarchy, default to mapping all items with a func.

### DIFF
--- a/feedforward/__init__.py
+++ b/feedforward/__init__.py
@@ -3,7 +3,7 @@ try:
 except ImportError:  # pragma: no cover
     __version__ = "dev"
 
-from .step import BaseStep, Step, State, Notification, NullStep
+from .step import Step, State, Notification
 from .run import Run
 
-__all__ = ["BaseStep", "Step", "Run", "State", "Notification", "NullStep"]
+__all__ = ["Step", "Run", "State", "Notification"]

--- a/feedforward/run.py
+++ b/feedforward/run.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from threading import Thread
 from typing import Generic, Iterable, TypeVar
 
-from .step import BaseStep, Step, Notification, State
+from .step import Step, Notification, State
 from .util import get_default_parallelism
 
 # Avoid a complete busy-wait in the worker threads when no work can be done;
@@ -71,7 +71,7 @@ class Run(Generic[K, V]):
     """
 
     def __init__(self, parallelism: int = 0, deliberate: bool = False):
-        self._steps: list[BaseStep[K, V]] = []
+        self._steps: list[Step[K, V]] = []
         self._running = False
         self._finalized_idx = -1
         self._threads: list[Thread] = []

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -11,7 +11,7 @@ def raiser(k, v):
 
 def test_exceptions_cancel():
     r = Run()
-    r.add_step(Step(func=raiser))
+    r.add_step(Step(map_func=raiser))
     r.add_step(Step())
     results = r.run_to_completion(
         {"filename": b"contents"},
@@ -25,8 +25,8 @@ def test_exceptions_cancel():
 
 def test_exceptions_keep_going():
     r = Run()
-    r.add_step(Step(func=raiser))
-    r.add_step(Step(func=replacer))
+    r.add_step(Step(map_func=raiser))
+    r.add_step(Step(map_func=replacer))
     r.add_step(Step())
     results = r.run_to_completion(
         {"filename": b"contents"},

--- a/tests/test_deliberate_mode.py
+++ b/tests/test_deliberate_mode.py
@@ -1,12 +1,12 @@
-from feedforward import Run, NullStep
+from feedforward import Run, Step
 
 
 def test_non_deliberate_right_edge():
     r: Run[str, str] = Run(deliberate=False)
     assert list(r._active_set()) == []
-    r.add_step(NullStep())
+    r.add_step(Step())
     assert list(r._active_set()) == [0]
-    r.add_step(NullStep())
+    r.add_step(Step())
     assert list(r._active_set()) == [0, 1]
 
     # Prevent step 1 from being finalizable yet
@@ -23,9 +23,9 @@ def test_non_deliberate_right_edge():
 def test_deliberate_right_edge():
     r: Run[str, str] = Run(deliberate=True)
     assert list(r._active_set()) == []
-    r.add_step(NullStep())
+    r.add_step(Step())
     assert list(r._active_set()) == [0]
-    r.add_step(NullStep())
+    r.add_step(Step())
     assert list(r._active_set()) == [0]
 
     # Prevent step 1 from being finalizable yet

--- a/tests/test_factorize.py
+++ b/tests/test_factorize.py
@@ -7,9 +7,6 @@ class FactorStep(feedforward.Step):
         super().__init__(concurrency_limit=concurrency_limit)
         self.factor = factor
 
-    def prepare(self):
-        pass
-
     def match(self, key):
         return True
 

--- a/tests/test_fizzbuzz.py
+++ b/tests/test_fizzbuzz.py
@@ -3,9 +3,6 @@ from feedforward import Notification, State
 
 
 class FizzStep(feedforward.Step):
-    def prepare(self):
-        pass
-
     def match(self, key):
         if key % 3 == 0:
             return True
@@ -21,9 +18,6 @@ class FizzStep(feedforward.Step):
 
 
 class BuzzStep(feedforward.Step):
-    def prepare(self):
-        pass
-
     def match(self, key):
         if key % 5 == 0:
             return True
@@ -39,9 +33,6 @@ class BuzzStep(feedforward.Step):
 
 
 class FizzBuzzStep(feedforward.Step):
-    def prepare(self):
-        pass
-
     def match(self, key):
         if key % 15 == 0:
             return True
@@ -57,23 +48,12 @@ class FizzBuzzStep(feedforward.Step):
             )
 
 
-class SinkStep(feedforward.Step):
-    def prepare(self):
-        pass
-
-    def match(self, key):
-        return True
-
-    def process(self, new_gen, notifications):
-        return ()
-
-
 def test_fizzbuzz():
     r = feedforward.Run(parallelism=2)
     r.add_step(FizzStep())
     r.add_step(BuzzStep())
     r.add_step(FizzBuzzStep())
-    r.add_step(SinkStep())
+    r.add_step(feedforward.Step())
 
     results = r.run_to_completion({k: str(k) for k in range(0, 20)})
 

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1,14 +1,14 @@
-from feedforward.step import State, Notification, NullStep
+from feedforward.step import State, Notification, Step
 
 
 def test_limited_step():
-    s = NullStep(concurrency_limit=0)
+    s = Step(concurrency_limit=0)
     s.index = 0
     assert not s.run_next_batch()  # parallelism reached
 
 
 def test_basic_step():
-    s = NullStep()
+    s = Step()
     s.index = 0
     assert not s.run_next_batch()  # no batch
 
@@ -18,7 +18,7 @@ def test_basic_step():
 
 
 def test_noneager_step():
-    s = NullStep(eager=False)
+    s = Step(eager=False)
     s.index = 0
     assert not s.run_next_batch()  # no batch
 
@@ -32,7 +32,7 @@ def test_noneager_step():
 
 
 def test_batch_size_small():
-    s = NullStep(batch_size=2)
+    s = Step(batch_size=2)
     s.index = 0
 
     assert not s.run_next_batch()  # no batch
@@ -48,7 +48,7 @@ def test_batch_size_small():
 
 
 def test_batch_size():
-    s = NullStep(batch_size=20)
+    s = Step(batch_size=20)
     s.index = 0
 
     assert not s.run_next_batch()  # no batch


### PR DESCRIPTION
This is the result of discussing BaseStep as well as writing out a real example in #12.  The common case is probably a 1:1 map, which is basically NullStep was already doing.

Subclasses are free to have `process` (or in more extreme cases, `run_next_batch`) yield multiple notifications, and the internal data structures for handling invalidation will probably change with #5 (gravitational constant).