### PR TITLE
Split outstanding into active + outstanding; fix finalization race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ setup:
 
 .PHONY: test
 test:
-	pytest --cov=feedforward --cov=tests --cov-report= $(TESTOPTS)
-	python -m coverage report
+	coverage run -m pytest $(TESTOPTS)
+	coverage report
 
 .PHONY: html
 html: .venv README.md docs/*.rst docs/conf.py

--- a/feedforward/run.py
+++ b/feedforward/run.py
@@ -147,18 +147,29 @@ class Run(Generic[K, V]):
                     notification = step.output_notifications.pop(0)
                 except IndexError:
                     break
+                step.outstanding.decrement()
                 self.feedforward(i + 1, notification)
         return result
 
     def _check_for_final(self) -> None:
-        while (
-            self._finalized_idx < len(self._steps) - 1
-            and not self._steps[self._finalized_idx + 1].unprocessed_notifications
-            and self._steps[self._finalized_idx + 1].outstanding == 0
-        ):
-            # TODO API for this
+        while self._finalized_idx < len(self._steps) - 1:
+            step = self._steps[self._finalized_idx + 1]
+            # All three counters are only ever mutated under state_lock, so a
+            # single locked read gives a consistent snapshot.  No fast unlocked
+            # path: we can't safely read active/outstanding without the lock.
+            with step.state_lock:
+                if (
+                    step.unprocessed_notifications
+                    or step.active != 0
+                    or step.outstanding != 0
+                ):
+                    break
+            if not step._last_call_done:
+                step._last_call_done = True
+                step.last_call()
+                continue  # Re-check conditions from scratch under the lock
             self._finalized_idx += 1
-            self._steps[self._finalized_idx].outputs_final = True
+            step.outputs_final = True
             if self._finalized_idx < len(self._steps) - 1:
                 self._steps[self._finalized_idx + 1].inputs_final = True
 

--- a/feedforward/step.py
+++ b/feedforward/step.py
@@ -7,7 +7,7 @@ import threading
 import traceback
 from dataclasses import dataclass, replace
 from logging import getLogger
-from typing import Any, Callable, Generic, Iterable, Optional, TypeVar
+from typing import Any, Callable, Generic, Iterable, Optional, SupportsIndex, TypeVar
 
 from .erasure import ERASURE
 
@@ -15,6 +15,78 @@ LOG = getLogger(__name__)
 
 K = TypeVar("K")
 V = TypeVar("V")
+
+class _GuardedInt:
+    """int wrapper that asserts a lock is held on every read and mutation."""
+
+    __slots__ = ("_value", "_lock")
+    _value: int
+    _lock: threading.Lock
+
+    def __init__(self, value: int, lock: threading.Lock) -> None:
+        object.__setattr__(self, "_value", value)
+        object.__setattr__(self, "_lock", lock)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("use increment() / decrement()")
+
+    def _check(self) -> None:
+        assert self._lock.locked()
+
+    def increment(self) -> None:
+        self._check()
+        object.__setattr__(self, "_value", self._value + 1)
+
+    def decrement(self) -> None:
+        self._check()
+        object.__setattr__(self, "_value", self._value - 1)
+
+    def peek(self) -> int:
+        """Read without requiring the lock — for display only."""
+        return self._value
+
+    def __bool__(self) -> bool:
+        self._check()
+        return self._value != 0
+
+    def __eq__(self, other: object) -> bool:
+        self._check()
+        return self._value == other
+
+    def __ne__(self, other: object) -> bool:
+        self._check()
+        return self._value != other
+
+    def __ge__(self, other: int) -> bool:
+        self._check()
+        return self._value >= other
+
+    def __repr__(self) -> str:
+        return repr(self._value)
+
+    def __format__(self, spec: str) -> str:
+        return format(self._value, spec)
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+class _GuardedList(list):  # type: ignore[type-arg]
+    """list subclass that asserts state_lock is held on every mutation."""
+
+    def __init__(self, step: Any) -> None:
+        super().__init__()
+        self._step = step
+
+    def _check(self) -> None:
+        assert self._step.state_lock.locked()
+
+    def append(self, item: Any) -> None:
+        self._check()
+        super().append(item)
+
+    def pop(self, index: SupportsIndex = -1) -> Any:
+        self._check()
+        return super().pop(index)
 
 
 @dataclass(frozen=True)
@@ -52,26 +124,60 @@ class Step(Generic[K, V]):
         self.cancelled: bool = False
         self.cancel_reason: str = ""
 
-        self.outstanding: int = 0
+        self.state_lock = threading.Lock()
+        self.active: _GuardedInt = _GuardedInt(0, self.state_lock)  # batches with process() in flight
+        self.outstanding: _GuardedInt = _GuardedInt(0, self.state_lock)  # items in output_notifications not yet forwarded
         # This is where they queue first
         self.unprocessed_notifications: list[Notification[K, V]] = []
         # These are ones actively in threads, which should only be replaced if
         # we're aware of a newer (or older, in the case of a rollback) sequence
         self.accepted_state: dict[K, State[V]] = {}
         self.output_state: dict[K, State[V]] = {}
-        self.output_notifications: list[Notification[K, V]] = []
+        self.output_notifications: list[Notification[K, V]] = _GuardedList(self)
         self.concurrency_limit = concurrency_limit
         self.eager = eager
         assert batch_size != 0  # but -1 is ok
         self.batch_size = batch_size
         self.map_func = map_func or (lambda k, v: v)
 
-        self.state_lock = threading.Lock()
+        # state_lock must be held for every read and write of the following
+        # fields.  _check_for_final reads them all in one acquisition to get a
+        # consistent snapshot; any unsynchronised access breaks that guarantee.
+        # active and outstanding are _GuardedInt, which enforces this at runtime.
+        #
+        #   active       – incremented when a batch is accepted from
+        #                  unprocessed_notifications; decremented (under lock)
+        #                  in the finally block after process() returns.
+        #   outstanding  – incremented each time a result is appended to
+        #                  output_notifications; decremented each time one is
+        #                  popped and forwarded in _pump.
+        #                  Invariant: outstanding == len(output_notifications)
+        #   output_notifications – completed results waiting to be forwarded.
+        #   output_state / accepted_state – consulted under lock when deciding
+        #                  whether a new result supersedes the current entry.
+        #   cancelled    – double-checked locking pattern in cancel().
+        #
+        # unprocessed_notifications is a partial exception: pops (run_next_batch)
+        # and clears (cancel) are under the lock, but appends from notify() and
+        # last_call() are not.  That is safe because those callers only run
+        # while an earlier step is still active — before this step's
+        # finalization window opens — so _check_for_final cannot be evaluating
+        # this step's readiness at the same time.
         self.index: Optional[int] = None  # Set in Run.add_step
         self.gen_counter = itertools.count(1)
+        self._last_call_done: bool = False
 
         self.stat_input_notifications = 0
         self.stat_output_notifications = 0
+
+    def last_call(self) -> None:
+        """
+        Called once when this step's inputs are exhausted and no batches are
+        outstanding.  Subclasses may enqueue additional work here (e.g. by
+        appending to ``unprocessed_notifications``); if they do, finalization
+        is deferred until the new work drains.  This method is only ever called
+        once per step instance.
+        """
 
     def match(self, key: K) -> bool:
         """
@@ -115,7 +221,7 @@ class Step(Generic[K, V]):
     def __repr__(self) -> str:
         # Note: self.gen_counter is intentional; there is no api to query the
         # current value other than repr
-        return f"<{self.__class__.__name__} f={self.outputs_final} g={self.gen_counter} o={self.outstanding}>"
+        return f"<{self.__class__.__name__} f={self.outputs_final} g={self.gen_counter} o={self.active}>"
 
     def cancel(self, reason: str) -> None:
         LOG.info("Cancel %s", reason)
@@ -145,9 +251,9 @@ class Step(Generic[K, V]):
                         state=state.with_changes(gens=gens),
                     )
                 )
+                self.outstanding.increment()
             # only eager depends on inputs_final today.
             # self.inputs_final = True
-            # self.outstanding = 0
             self.outputs_final = True
             for k, state in self.output_state.items():
                 if k not in self.accepted_state:
@@ -158,6 +264,7 @@ class Step(Generic[K, V]):
                             state=state.with_changes(gens=gens, value=ERASURE),
                         )
                     )
+                    self.outstanding.increment()
             # Don't need to clear output_notifications;
             # Do need to clear unprocessed so that we can be finalized by Run
             del self.unprocessed_notifications[:]
@@ -207,7 +314,7 @@ class Step(Generic[K, V]):
         with self.state_lock:
             if (
                 self.concurrency_limit is not None
-                and self.outstanding >= self.concurrency_limit
+                and self.active >= self.concurrency_limit
             ):
                 return False
 
@@ -226,14 +333,13 @@ class Step(Generic[K, V]):
                     q[item.key] = item
                     self.stat_input_notifications += 1
 
-            # We need to increment this with the lock still held
             if q:
                 gen = next(self.gen_counter)
+                self.active.increment()
             else:
                 return False
 
         try:
-            self.outstanding += 1
             assert self.index is not None
             for result in self.process(gen, iter(q.values())):
                 assert sum(result.state.gens[self.index + 1 :]) == 0
@@ -246,6 +352,7 @@ class Step(Generic[K, V]):
                         # might check that the value is different before notifying?
                         self.output_state[result.key] = result.state
                         self.output_notifications.append(result)
+                        self.outstanding.increment()
                         self.stat_output_notifications += 1
         except Exception as e:
             typ, value, tb = sys.exc_info()
@@ -254,7 +361,8 @@ class Step(Generic[K, V]):
             print(repr(e), file=buf)
             self.cancel(buf.getvalue())
         finally:
-            self.outstanding -= 1
+            with self.state_lock:
+                self.active.decrement()
 
         return True
 
@@ -266,7 +374,7 @@ class Step(Generic[K, V]):
             return "🔴"
         elif self.outputs_final:
             return "💚"
-        elif self.outstanding:
+        elif self.active.peek():
             return "🏃"
         elif self.unprocessed_notifications:
             return "🪣"

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ docs =
 test =
     coverage >= 6
     pytest
-    pytest-cov
     tokenize-rt
 
 [options.entry_points]

--- a/tests/test_deliberate_mode.py
+++ b/tests/test_deliberate_mode.py
@@ -10,7 +10,8 @@ def test_non_deliberate_right_edge():
     assert list(r._active_set()) == [0, 1]
 
     # Prevent step 1 from being finalizable yet
-    r._steps[1].outstanding = 1
+    with r._steps[1].state_lock:
+        r._steps[1].active.increment()
 
     r._check_for_final()
     assert list(r._active_set()) == [1]
@@ -29,7 +30,8 @@ def test_deliberate_right_edge():
     assert list(r._active_set()) == [0]
 
     # Prevent step 1 from being finalizable yet
-    r._steps[1].outstanding = 1
+    with r._steps[1].state_lock:
+        r._steps[1].active.increment()
 
     r._check_for_final()
     assert list(r._active_set()) == [1]

--- a/tests/test_last_call.py
+++ b/tests/test_last_call.py
@@ -1,0 +1,150 @@
+"""Tests for the last_call() finalization hook on Step."""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Iterator
+
+from feedforward import Notification, Run, State, Step
+from feedforward.run import PERIODIC_WAIT
+
+
+class CountingLastCall(Step[str, str]):
+    """Records how many times last_call() is invoked."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.last_call_count = 0
+
+    def last_call(self) -> None:
+        self.last_call_count += 1
+
+
+class RequeueOnLastCall(Step[str, str]):
+    """
+    On last_call(), re-processes every key through a second transformation.
+    Simulates the 'redo per-key at the end' use-case.
+    """
+
+    def __init__(self, suffix: str, **kwargs):
+        super().__init__(**kwargs)
+        self.suffix = suffix
+        self.last_call_invoked = False
+
+    def process(
+        self, next_gen: int, notifications: Iterator[Notification[str, str]]
+    ) -> Iterator[Notification[str, str]]:
+        for n in notifications:
+            yield self.update_notification(n, next_gen, n.state.value + self.suffix)
+
+    def last_call(self) -> None:
+        self.last_call_invoked = True
+        # Re-enqueue all output keys so they get a second pass.
+        for key, state in list(self.output_state.items()):
+            self.unprocessed_notifications.append(Notification(key=key, state=state))
+
+
+def _run(steps, inputs):
+    r = Run(parallelism=1)
+    for s in steps:
+        r.add_step(s)
+    return r.run_to_completion(inputs)
+
+
+def test_last_call_not_called_on_default_step():
+    """The base Step.last_call() is a no-op and shouldn't break anything."""
+    step = Step(map_func=lambda k, v: v.upper())
+    result = _run([step], {"a": "hello", "b": "world"})
+    assert result["a"].value == "HELLO"
+    assert result["b"].value == "WORLD"
+
+
+def test_last_call_called_exactly_once():
+    step = CountingLastCall(map_func=lambda k, v: v)
+    _run([step], {"x": "1", "y": "2", "z": "3"})
+    assert step.last_call_count == 1
+
+
+def test_last_call_called_once_with_no_inputs():
+    step = CountingLastCall(map_func=lambda k, v: v)
+    _run([step], {})
+    assert step.last_call_count == 1
+
+
+def test_last_call_work_is_processed():
+    """Work enqueued in last_call() must be fully processed before the step finalizes."""
+    suffix_step = RequeueOnLastCall(suffix="!")
+    result = _run([suffix_step], {"a": "hi", "b": "bye"})
+    # First pass: "hi" -> "hi!", "bye" -> "bye!"
+    # last_call re-enqueues those; second pass: "hi!" -> "hi!!", "bye!" -> "bye!!"
+    assert result["a"].value == "hi!!"
+    assert result["b"].value == "bye!!"
+    assert suffix_step.last_call_invoked
+
+
+def test_last_call_called_once_even_after_requeue():
+    """last_call() must only be called once, even when it adds more work."""
+    call_count = 0
+
+    class OnceChecker(Step[str, str]):
+        def last_call(self):
+            nonlocal call_count
+            call_count += 1
+            # Add work — but last_call must not be called again
+            for key, state in list(self.output_state.items()):
+                self.unprocessed_notifications.append(Notification(key=key, state=state))
+
+    step = OnceChecker(map_func=lambda k, v: v)
+    _run([step], {"a": "1"})
+    assert call_count == 1
+
+
+def test_last_call_each_step_called_once():
+    """Each step in a multi-step pipeline gets its own last_call() invocation."""
+    step1 = CountingLastCall(map_func=lambda k, v: v + "1")
+    step2 = CountingLastCall(map_func=lambda k, v: v + "2")
+    _run([step1, step2], {"x": "start"})
+    assert step1.last_call_count == 1
+    assert step2.last_call_count == 1
+
+
+def test_locked_recheck_fires_on_injected_race():
+    """Cover the locked finalization check by injecting work while holding the lock.
+
+    The background thread spins (releasing briefly each lap) until the step
+    looks finalizable: output produced, nothing queued, no active batch.  It
+    then holds state_lock continuously and sleeps long enough for
+    _check_for_final() — which now goes straight to acquiring the lock with no
+    fast path — to block on it.  The thread injects into output_notifications
+    (incrementing outstanding to maintain the invariant) before releasing.
+    _check_for_final() then sees outstanding != 0 and defers finalization until
+    the injected item is drained.
+    """
+    step = Step(map_func=lambda k, v: v.upper())
+    r = Run(parallelism=1)
+    r.add_step(step)
+
+    def inject_race():
+        # Spin with brief lock releases until the step looks finalizable, then
+        # hold the lock so _check_for_final() blocks trying to acquire it.
+        step.state_lock.acquire()
+        try:
+            while not step.output_state or step.output_notifications or step.active:
+                step.state_lock.release()
+                time.sleep(0.001)
+                step.state_lock.acquire()
+            # We hold the lock; _check_for_final() is now blocking on it.
+            # Sleep long enough for that to happen.
+            time.sleep(4 * PERIODIC_WAIT)
+            # Inject while the main thread is blocked — the locked check sees this.
+            key, state = next(iter(step.output_state.items()))
+            step.output_notifications.append(Notification(key=key, state=state))
+            step.outstanding.increment()  # maintain outstanding == len(output_notifications)
+        finally:
+            step.state_lock.release()
+
+    t = threading.Thread(target=inject_race, daemon=True)
+    t.start()
+    result = r.run_to_completion({"a": "hello"})
+    t.join()
+    assert result["a"].value == "HELLO"

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -132,10 +132,12 @@ def test_emoji():
     s.notify(Notification(key="x", state=State(gens=(0,), value="x")))
     assert s.emoji() == "🪣"  # has unprocessed notifications
 
-    s.outstanding = 1
+    with s.state_lock:
+        s.active.increment()
     assert s.emoji() == "🏃"  # running (takes priority over unprocessed)
 
-    s.outstanding = 0
+    with s.state_lock:
+        s.active.decrement()
     del s.unprocessed_notifications[:]
     s.outputs_final = True
     assert s.emoji() == "💚"  # complete

--- a/tests/test_stress.py
+++ b/tests/test_stress.py
@@ -1,0 +1,113 @@
+"""
+High-concurrency stress test for the active/outstanding split.
+
+Exercises the finalization path under heavy load: many steps, many keys,
+high parallelism, repeated iterations.  Any spurious assert in notify()
+or incorrect final state will surface here.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from feedforward import Run, Step
+
+
+def _make_append_step(char: str) -> Step[str, str]:
+    return Step(map_func=lambda k, v: v + char)
+
+
+def _run_stress(
+    *,
+    n_steps: int,
+    n_keys: int,
+    parallelism: int,
+    batch_size: int = 5,
+) -> float:
+    """
+    Build a pipeline of n_steps append-steps, feed n_keys inputs, and
+    return elapsed seconds.  Asserts correctness of every output value.
+    """
+    chars = [chr(ord("a") + (i % 26)) for i in range(n_steps)]
+    steps = [_make_append_step(c) for c in chars]
+    r: Run[str, str] = Run(parallelism=parallelism)
+    for s in steps:
+        r.add_step(s)
+
+    inputs = {f"k{i}": "" for i in range(n_keys)}
+    expected = "".join(chars)
+
+    t0 = time.monotonic()
+    result = r.run_to_completion(inputs)
+    elapsed = time.monotonic() - t0
+
+    assert len(result) == n_keys
+    for key, state in result.items():
+        assert state.value == expected, f"{key}: {state.value!r} != {expected!r}"
+
+    return elapsed
+
+
+# ----- individual parametrised cases ----------------------------------------
+
+@pytest.mark.parametrize("parallelism", [1, 2, 4, 8])
+def test_stress_parallelism(parallelism):
+    """Vary worker count; correctness must hold at all levels."""
+    _run_stress(n_steps=8, n_keys=200, parallelism=parallelism)
+
+
+@pytest.mark.parametrize("n_steps", [1, 3, 10, 20])
+def test_stress_step_count(n_steps):
+    """More steps = more finalization boundaries to race across."""
+    _run_stress(n_steps=n_steps, n_keys=100, parallelism=4)
+
+
+def test_stress_many_keys():
+    """Many keys at high parallelism — output_notifications drains under contention."""
+    _run_stress(n_steps=6, n_keys=2000, parallelism=8, batch_size=20)
+
+
+def test_stress_many_steps_high_concurrency():
+    """
+    The hardest case: 20 steps × 500 keys × 8 workers.
+    Each step finalizes in sequence; this maximises the window where
+    _check_for_final races workers draining the previous step's
+    output_notifications.
+    """
+    elapsed = _run_stress(n_steps=20, n_keys=500, parallelism=8)
+    # Loose upper bound — should complete well within 30 s on any reasonable machine
+    assert elapsed < 30, f"took {elapsed:.1f}s — possible livelock"
+
+
+def test_stress_repeated():
+    """
+    Run the same pipeline 20 times back-to-back.  Any flaky race shows up
+    as a non-deterministic failure here.
+    """
+    for _ in range(20):
+        _run_stress(n_steps=5, n_keys=50, parallelism=4)
+
+
+class SlowProcessStep(Step[str, str]):
+    """Yields after a tiny sleep to widen the race window."""
+
+    def process(self, next_gen, notifications):
+        import time as _time
+        for n in notifications:
+            _time.sleep(0.001)
+            yield self.update_notification(n, next_gen, n.state.value + "!")
+
+
+def test_stress_slow_process():
+    """
+    process() that sleeps makes _check_for_final more likely to interleave
+    with the drain loop; checks the inputs_final assert never fires.
+    """
+    steps = [SlowProcessStep() for _ in range(4)]
+    r: Run[str, str] = Run(parallelism=4)
+    for s in steps:
+        r.add_step(s)
+    result = r.run_to_completion({f"k{i}": "" for i in range(20)})
+    for state in result.values():
+        assert state.value == "!!!!"


### PR DESCRIPTION
The old single `outstanding` counter was overloaded: it covered both
batches with `process()` in flight and results sitting in
`output_notifications` waiting to be forwarded.  That ambiguity let
`_check_for_final` see `outstanding == 0` and mark a step final while
results were still queued, causing dropped notifications under
concurrency.

This change splits it into `active` (process() in flight) and
`outstanding` (items in output_notifications not yet forwarded).
`_check_for_final` now acquires `state_lock` once to read all three
counters as a consistent snapshot.  `_GuardedList` and a `__setattr__`
override enforce the locking discipline statically.
`unprocessed_notifications` appends remain intentionally unlocked — they
only occur before the finalization window opens for a given step.

Also adds `last_call()`, a hook called exactly once when a step's inputs
are exhausted and all batches have drained, so subclasses can emit
trailing work without fighting the finalizer.